### PR TITLE
Add AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ also be used to give our FQL in-browser REPLs and integrate into existing toolin
 ## Usage
 
 Install it with:
+
 ```
 yarn add @segment/fql
 ```
@@ -137,6 +138,72 @@ If we have errors during the unlexing, we'll return an `error` object, just like
 
 ```js
 const { error } = unlex(dangerousErrorTokens)
+```
+
+### AST
+
+We can create a typed AST from an array of tokens.
+
+```js
+import { ast, lex } from '@segment/fql'
+
+const { tokens } = lex(`message = "foo"`)
+const { node } = ast(tokens)
+```
+
+The AST returns the _root_ node of the tree which will always have the `node.type` of `ROOT`.
+
+Each node is in a format like this:
+
+```ts
+const node = {
+  leaves: []
+  nodes: []
+  type: "Expr"
+}
+```
+
+Leaves are arrays of tokens, nodes are other nodes. The type is an enum defined with `AbstractSyntaxType`. If you're using typescript, they're defined as:
+
+```ts
+export enum AbstractSyntaxType {
+  ROOT = 'root',
+  EXPR = 'expr',
+  PATH = 'path',
+  FUNC = 'func',
+  ERR = 'err',
+  OPERATOR = 'OPERATOR'
+}
+
+export interface Node {
+  leaves: Token[]
+  nodes: Node[]
+  type: AbstractSyntaxType
+}
+```
+
+If something went wrong in the parsing, the AST will return an error and the last node will be of type `ERR`:
+
+```js
+import { ast, lex } from '@segment/fql'
+
+const { tokens } = lex(`message = `)
+const { node, error } = ast(tokens)
+
+console.error(error) // "ParserError: ..."
+```
+
+#### There and Back Again
+
+You can go from an AST to tokens pretty easily with `astToTokens`:
+
+```js
+import { astToTokens, lex, ast } from '@segment/fql'
+
+const { tokens } = lex(`message = "foo"`)
+const { node } = ast(tokens)
+
+astToTokens(node) // same thing as tokens
 ```
 
 ## Contributing

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -1,4 +1,4 @@
-import ast, { AbstractSyntaxType } from './ast'
+import ast, { AbstractSyntaxType, astToTokens } from './ast'
 import lex from './lexer'
 import { TokenType } from './token'
 
@@ -113,4 +113,11 @@ test('Literals are recorded correctly', () => {
   expect(node.nodes[2].type).toBe(AbstractSyntaxType.EXPR)
   expect(node.nodes[2].leaves[0].type).toBe(TokenType.String)
   expect(node.nodes[2].leaves[0].value).toBe(`"foo"`)
+})
+
+test('astToTokens can correctly convert to tokens', () => {
+  const { tokens } = lex(`message = "foo"`)
+  const { node } = ast(tokens)
+
+  expect(astToTokens(node)).toEqual(tokens)
 })

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -36,13 +36,37 @@ interface AstResponse {
 
 export default function ast(tokens: Token[]): AstResponse {
   try {
-    return { node: new Parser(tokens).parse() }
+    // we .slice() here to avoid destroying the array
+    return { node: new Parser(tokens.slice()).parse() }
   } catch (error) {
     return {
       node: newNode(AbstractSyntaxType.ERR),
       error
     }
   }
+}
+
+export function astToTokens(node: Node): Token[] {
+  const tokens = traverseAstForTokens(node)
+
+  // AST doesn't record the EOS, so we add it back
+  tokens.push(t.EOS())
+
+  return tokens
+}
+
+function traverseAstForTokens(node: Node): Token[] {
+  let tokens = []
+
+  for (const child of node.nodes) {
+    tokens = tokens.concat(traverseAstForTokens(child))
+  }
+
+  if (node.leaves.length > 0) {
+    tokens = tokens.concat(node.leaves)
+  }
+
+  return tokens
 }
 
 export class Parser {


### PR DESCRIPTION
Adds an `ast` function that takes an array of tokens and spits out an abstract syntax tree.

```js
import {ast, lex} from 'fql'

const { tokens } = lex(`message = "dogs"`)
const { node } = ast(tokens)
```