### PR TITLE
include ts declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
+    "declaration": true,
     "resolveJsonModule": true,
     "paths": {
       "*": ["node_modules/*", "src/types/*"]


### PR DESCRIPTION
This PR tells the TypeScript compiler to include typedef declaration files (`.d.ts`) so it can be consumed more easily in TypeScript projects!