### PR TITLE
Support negation

### DIFF
--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -243,3 +243,28 @@ test('Lexer passes new line fixtures', () => {
     )
   ])
 })
+
+test('Lexer passes negations', () => {
+  testFixtures([
+    fix('!true', [t.Operator('!'), t.Ident('true'), t.EOS()], false),
+    fix('!(event = "X")', [
+      t.Operator('!'),
+      t.ParenLeft(),
+      t.Ident('event'),
+      t.Operator('='),
+      t.String('"X"'),
+      t.ParenRight(),
+      t.EOS()
+    ], false),
+    fix('!contains(event, "X")', [
+      t.Operator('!'),
+      t.Ident('contains'),
+      t.ParenLeft(),
+      t.Ident('event'),
+      t.Comma(),
+      t.String('"X"'),
+      t.ParenRight(),
+      t.EOS()
+    ], false)
+  ])
+})

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -69,6 +69,15 @@ export class Lexer {
         continue
       }
 
+      if (char === '!') {
+        const nextChar = this.peek()
+
+        if (isAlpha(nextChar) || nextChar === '(') {
+          tokens.push(t.Operator('!'))
+          continue
+        }
+      }
+
       if (isAlpha(char) || char === '!' || char === '=' || char === '>' || char === '<') {
         tokens.push(this.lexOperatorOrConditional(char))
         continue


### PR DESCRIPTION
`fql-ts` didn't support lexing FQL with negation before:

- `!true`
- `!(event = "X")`
- `!contains(event, "X")`