### PR TITLE
Handle strings beginning with an underscore

### DIFF
--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -186,6 +186,14 @@ test('Lexer passes dot fixtures', () => {
   ])
 })
 
+test('Lexer passes underscore fixtures', () => {
+  testFixtures([
+    fix('_ab', [t.Underscore(), t.Ident('a'), t.Ident('b'), t.EOS()], false),
+    fix('a_b', [t.Ident('a'), t.Underscore(), t.Ident('b'), t.EOS()], false),
+    fix('ab_', [t.Ident('a'), t.Ident('b'), t.Underscore(), t.EOS()], false),
+  ])
+})
+
 // Don't screw with any of the whitespace here, that's the point of the test
 test('Lexer passes new line fixtures', () => {
   testFixtures([

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -188,9 +188,9 @@ test('Lexer passes dot fixtures', () => {
 
 test('Lexer passes underscore fixtures', () => {
   testFixtures([
-    fix('_ab', [t.Underscore(), t.Ident('a'), t.Ident('b'), t.EOS()], false),
-    fix('a_b', [t.Ident('a'), t.Underscore(), t.Ident('b'), t.EOS()], false),
-    fix('ab_', [t.Ident('a'), t.Ident('b'), t.Underscore(), t.EOS()], false),
+    fix('_ab', [t.Ident('_ab'), t.EOS()], false),
+    fix('a_b', [t.Ident('a_b'), t.EOS()], false),
+    fix('ab_', [t.Ident('ab_'), t.EOS()], false),
   ])
 })
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -78,7 +78,7 @@ export class Lexer {
         }
       }
 
-      if (isAlpha(char) || char === '!' || char === '=' || char === '>' || char === '<') {
+      if (isAlpha(char) || char === '!' || char === '=' || char === '>' || char === '<' || char === '_') {
         tokens.push(this.lexOperatorOrConditional(char))
         continue
       }
@@ -112,7 +112,7 @@ export class Lexer {
         tokens.push(t.Comma())
         continue
       }
-
+      
       if (char === '(') {
         tokens.push(t.ParenLeft())
         continue

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -112,7 +112,7 @@ export class Lexer {
         tokens.push(t.Comma())
         continue
       }
-      
+
       if (char === '(') {
         tokens.push(t.ParenLeft())
         continue

--- a/src/token.ts
+++ b/src/token.ts
@@ -23,6 +23,7 @@ export enum TokenType {
   ParenLeft = 'parenleft',
   ParenRight = 'parenright',
   Comma = 'comma',
+  Underscore = 'underscore',
   EOS = 'eos'
 }
 
@@ -78,6 +79,10 @@ export const t = {
 
   Comma: (): Token => {
     return { type: TokenType.Comma, value: ',' }
+  },
+
+  Underscore: (): Token => {
+    return { type: TokenType.Underscore, value: '_' }
   },
 
   EOS: (): Token => {


### PR DESCRIPTION
This PR fixes `lex` for keys starting with `_`.

We need to make the change in the Go FQL library go before this change can be deployed: https://github.com/segmentio/fql/pull/56

## Testing
- [ ] New unit tests
- [ ] Test in stage

## Steps to deploy
- [ ] First, deploy the change to the Go FQL library: https://github.com/segmentio/fql/pull/56
- [ ] Merge change and bump version.
- [ ] Test gateway-api with updated fql-ts change in stage.
- [ ] Deploy gateway-api to prod with updated fql-ts.